### PR TITLE
Remove the concept of an explicit 'blank vote'

### DIFF
--- a/app.css
+++ b/app.css
@@ -76,12 +76,6 @@ button#simulate:hover {
   fill: #d62728;
 }
 
-.vote.blank {
-  stroke: #ccc;
-  stroke-width: 1px;
-  fill: white;
-}
-
 .vote.isDelegated {
   opacity: .7;
 }

--- a/app.js
+++ b/app.js
@@ -154,8 +154,6 @@ function tallyVotes(votesByVoterUid) {
     votes_yay_from_delegate: 0,
     votes_nay: 0,
     votes_nay_from_delegate: 0,
-    votes_blank: 0,
-    votes_blank_from_delegate: 0,
     votes_no_vote: 0,
   }
 
@@ -187,7 +185,6 @@ function tallyVotes(votesByVoterUid) {
   circle
     .data(force.nodes())
     .attr('class', function (d) { return 'vote ' + d.vote + (d.isDelegated ? ' isDelegated' : '') })
-    .attr('r', function (d) { return d.vote === 'blank' ? 8 : 10 })
 
   document.getElementById('yay-count').innerText = bill.votes_yay + bill.votes_yay_from_delegate
   document.getElementById('nay-count').innerText = bill.votes_nay + bill.votes_nay_from_delegate
@@ -209,7 +206,7 @@ document.getElementById('simulate').onclick = function () {
 }
 
 function clickVoter(voterUid) {
-  var positions = ['yay', 'nay', 'blank', 'no_vote']
+  var positions = ['yay', 'nay', 'no_vote']
 
   var newPosition
 

--- a/bundle.js
+++ b/bundle.js
@@ -155,8 +155,6 @@ function tallyVotes(votesByVoterUid) {
     votes_yay_from_delegate: 0,
     votes_nay: 0,
     votes_nay_from_delegate: 0,
-    votes_blank: 0,
-    votes_blank_from_delegate: 0,
     votes_no_vote: 0,
   }
 
@@ -188,7 +186,6 @@ function tallyVotes(votesByVoterUid) {
   circle
     .data(force.nodes())
     .attr('class', function (d) { return 'vote ' + d.vote + (d.isDelegated ? ' isDelegated' : '') })
-    .attr('r', function (d) { return d.vote === 'blank' ? 8 : 10 })
 
   document.getElementById('yay-count').innerText = bill.votes_yay + bill.votes_yay_from_delegate
   document.getElementById('nay-count').innerText = bill.votes_nay + bill.votes_nay_from_delegate
@@ -210,7 +207,7 @@ document.getElementById('simulate').onclick = function () {
 }
 
 function clickVoter(voterUid) {
-  var positions = ['yay', 'nay', 'blank', 'no_vote']
+  var positions = ['yay', 'nay', 'no_vote']
 
   var newPosition
 
@@ -286,8 +283,8 @@ module.exports = [
 module.exports = function generateRandomVotes(voters) {
   var votes = []
   for (var i = 0; i < voters.length; i++) {
-    // Pick a random position: 'yay', 'nay', 'blank' (explicit abstain), 'no_vote' (inherits)
-    var position = ['yay', 'nay', 'blank', 'no_vote'][Math.floor(Math.random() * 4)]
+    // Pick a random position: 'yay', 'nay', 'no_vote' (inherits)
+    var position = ['yay', 'nay', 'no_vote'][Math.floor(Math.random() * 3)]
 
     if (position !== 'no_vote') {
       votes.push({

--- a/generate-random-votes.js
+++ b/generate-random-votes.js
@@ -1,8 +1,8 @@
 module.exports = function generateRandomVotes(voters) {
   var votes = []
   for (var i = 0; i < voters.length; i++) {
-    // Pick a random position: 'yay', 'nay', 'blank' (explicit abstain), 'no_vote' (inherits)
-    var position = ['yay', 'nay', 'blank', 'no_vote'][Math.floor(Math.random() * 4)]
+    // Pick a random position: 'yay', 'nay', 'no_vote' (inherits)
+    var position = ['yay', 'nay', 'no_vote'][Math.floor(Math.random() * 3)]
 
     if (position !== 'no_vote') {
       votes.push({

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   </head>
 
   <body>
-    <h1>Liquid Democracy Simulation</h1>
+    <h1>Liquid Democracy Simulation — Delegation</h1>
     <button id="simulate">Simulate new vote</button>
     <div id="vote-tally">
       <p class="yay-label">

--- a/tally-votes.js
+++ b/tally-votes.js
@@ -28,8 +28,6 @@ var bill = {
   votes_yay_from_delegate: 0,
   votes_nay: 0,
   votes_nay_from_delegate: 0,
-  votes_blank: 0,
-  votes_blank_from_delegate: 0,
   votes_no_vote: 0,
 }
 
@@ -99,7 +97,6 @@ var finalTally = {
   voted: voters.length - bill.votes_no_vote, // is there a quorum?
   potential_voters: voters.length,
   delegated: bill.votes_yay_from_delegate
-    + bill.votes_nay_from_delegate
-    + bill.votes_blank_from_delegate,
+    + bill.votes_nay_from_delegate,
 }
 console.log('\nfinalTally:', finalTally)


### PR DESCRIPTION
The first working version of the [vote-tallying algorithm](https://github.com/liquidvote/liquid-api/commit/86df5b23dddd0fa91d13f06e2c822681400f505d#diff-9a3ce22407d397b68540aba9a14d2875R36) allowed for 4 possible voter positions:
1. `for`
2. `against`
3. `abstain` (explicit)
4. `no vote` (inherits)

This third option, `abstain`, [was already renamed to `blank`](https://github.com/liquidvote/demo/commit/0a43671ddcf391669651f5303c348cd35c881d15#diff-9a3ce22407d397b68540aba9a14d2875L36) to clarify [the distinction between not showing up vs being present but not preferring either `yay` or `nay`](https://en.wikipedia.org/wiki/Abstention).

The idea was to match the same options available in existing voting systems, which sometimes include a "present" vote which doesn't count either way.

In the vote-tallying algorithm, `blank` votes are treated as an explicit "don't inherit from my delegate", _and_ don't count me as for or against. Contrast that with any other explicit vote, which override a delegate, and simply not voting, which inherits.

But after sharing a working version of the demo with other people, who were otherwise enthusiastic about this project, it's clear that this `blank` option is confusing. And it's not even all that obvious what its use-case is for Liquid Democracy. It seems to convey "I don't trust my delegate", which is more easily solved by changing your delegate.

So, I propose we remove this `blank` vote for now. That will make the whole system easier to understand (which is already a challenge) and if it becomes compelling we can always add it back as an option.

Now the positions would be:
1. `for`
2. `against`
3. `no vote` (inherits)
